### PR TITLE
Serve Avatars directly from Directus

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@uidotdev/usehooks": "^2.4.1",
     "astro": "^4.5.8",
     "classnames": "^2.5.1",
-    "random-avatar-generator": "^2.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-spring-carousel": "^2.0.19"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
-      random-avatar-generator:
-        specifier: ^2.0.0
-        version: 2.0.0
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -4145,9 +4142,6 @@ packages:
   queue@6.0.2:
     resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
 
-  random-avatar-generator@2.0.0:
-    resolution: {integrity: sha512-yOLrLkw2CvNuF2sFT23no9Qt7Lz16LS7gw6lVTc5M3TmBAKJEkxX8PZ4PYfxyXOEbnAJt4ttS4tUK+hUlXmLsQ==}
-
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -4458,9 +4452,6 @@ packages:
   section-matter@1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
     engines: {node: '>=4'}
-
-  seedrandom@3.0.5:
-    resolution: {integrity: sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==}
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -10719,10 +10710,6 @@ snapshots:
     dependencies:
       inherits: 2.0.4
 
-  random-avatar-generator@2.0.0:
-    dependencies:
-      seedrandom: 3.0.5
-
   range-parser@1.2.1: {}
 
   rc@1.2.8:
@@ -11206,8 +11193,6 @@ snapshots:
     dependencies:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
-
-  seedrandom@3.0.5: {}
 
   semver@5.7.2: {}
 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,2 @@
+/// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />

--- a/src/types/directus.types.ts
+++ b/src/types/directus.types.ts
@@ -1,0 +1,39 @@
+interface ICCMetadata {
+  version: string;
+  intent: string;
+  cmm: string;
+  deviceClass: string;
+  colorSpace: string;
+  connectionSpace: string;
+  platform: string;
+  creator: string;
+  description: string;
+  copyright: string;
+}
+
+export interface FileMetadata {
+  id: string;
+  storage: string;
+  filename_disk: string;
+  filename_download: string;
+  title: string;
+  type: string;
+  folder: string | null;
+  created_on: string;
+  uploaded_by: string;
+  uploaded_on: string;
+  modified_by: string | null;
+  modified_on: string;
+  filesize: number;
+  width: number;
+  height: number;
+  focal_point_x: number | null;
+  focal_point_y: number | null;
+  duration: number | null;
+  description: string | null;
+  location: string | null;
+  tags: string[];
+  metadata: {
+    icc: ICCMetadata;
+  };
+}

--- a/src/utils/directus.ts
+++ b/src/utils/directus.ts
@@ -1,33 +1,54 @@
-import {createDirectus, readItems, rest, staticToken} from '@directus/sdk';
+import {
+  createDirectus,
+  readFile,
+  readItems,
+  rest,
+  staticToken,
+} from "@directus/sdk";
 
 const directusUrl = import.meta.env.DIRECTUS_URL;
 const directusToken = import.meta.env.DIRECTUS_TOKEN;
 
 const directusClient = createDirectus(directusUrl)
-    .with(staticToken(directusToken))
-    .with(rest());
+  .with(staticToken(directusToken))
+  .with(rest());
 
-export default async function getTranslatedContent(collection: string, language: string) {
-    const content = await directusClient.request<{id: string, translations: [Record<string, any>]}>(readItems(collection, {
-        deep: {
-            translations: {
-                _filter: {
-                    languages_code: {
-                        _eq: language
-                    },
-                },
+export default async function getTranslatedContent(
+  collection: string,
+  language: string,
+) {
+  const content = await directusClient.request<{
+    id: string;
+    translations: [Record<string, any>];
+  }>(
+    readItems(collection, {
+      deep: {
+        translations: {
+          _filter: {
+            languages_code: {
+              _eq: language,
             },
+          },
         },
-        fields: ['*', 'translations.*'],
-        limit: 1
-    }));
+      },
+      fields: ["*", "translations.*"],
+      limit: 1,
+    }),
+  );
 
-    return content.translations[0];
+  return content.translations[0];
 }
 
 export async function getContent(collection: string) {
-    const content = await directusClient.request(readItems(collection, {
-      fields: ['*.*'],
-    }));
-    return content;
+  console.log(directusUrl, directusToken);
+
+  console.log(
+    `${directusUrl}/assets/${"cc030b8a-4742-41a6-930a-f2aa65959de2"}`,
+  );
+  const content = await directusClient.request(
+    readItems(collection, {
+      fields: ["*.*"],
+    }),
+  );
+  return content;
 }

--- a/src/utils/directus.ts
+++ b/src/utils/directus.ts
@@ -40,11 +40,6 @@ export default async function getTranslatedContent(
 }
 
 export async function getContent(collection: string) {
-  console.log(directusUrl, directusToken);
-
-  console.log(
-    `${directusUrl}/assets/${"cc030b8a-4742-41a6-930a-f2aa65959de2"}`,
-  );
   const content = await directusClient.request(
     readItems(collection, {
       fields: ["*.*"],

--- a/src/views/Feedback/Feedback.astro
+++ b/src/views/Feedback/Feedback.astro
@@ -2,16 +2,25 @@
 import { getLangFromUrl } from "src/i18n/utils";
 import FeedbackCarousel from "./FeedbackCarousel.tsx";
 import getTranslatedContent, { getContent } from "../../utils/directus";
+import type { FileMetadata } from "src/types/directus.types";
 
 const lang = getLangFromUrl(Astro.url);
 const content = await getTranslatedContent("Feedback_Section", lang);
 const testimonials = (await getContent("testimonials")) as FeedbackItem[];
+const directusUrl = import.meta.env.DIRECTUS_URL;
+
+testimonials.forEach((testimonial) => {
+  if (testimonial.image) {
+    testimonial.imageUrl = `${directusUrl}/assets/${testimonial.image.id}`;
+  }
+});
 
 export type FeedbackItem = {
   name: string;
   role?: string;
   company?: string;
-  image?: string;
+  image: FileMetadata;
+  imageUrl?: string;
   feedback: string;
 };
 ---

--- a/src/views/Feedback/FeedbackCard.tsx
+++ b/src/views/Feedback/FeedbackCard.tsx
@@ -1,4 +1,3 @@
-import { AvatarGenerator } from "random-avatar-generator";
 import type { FeedbackItem } from "./Feedback.astro";
 
 const FeedbackCard = (item: FeedbackItem, posistionPercentage: number) => {
@@ -16,13 +15,7 @@ const FeedbackCard = (item: FeedbackItem, posistionPercentage: number) => {
     >
       <p className="feedback_card-text">{item.feedback}</p>
       <div className="feedback_card-author">
-        <img
-          src={
-            item.image ??
-            new AvatarGenerator().generateRandomAvatar(item.name + item.company)
-          }
-          alt={item.name}
-        />
+        <img src={item.imageUrl} alt={item.name} />
         <div className="feedback_card-author-info">
           <span className="feedback_card-author-name">{item.name}</span>
           <span className="feedback_card-author-position">


### PR DESCRIPTION
Previously, we generated the Avatars on the Feedback Cards during runtime by sending requests to a third-party service using a third-party library.

I added Avatars as SVG files to our directus CMS. These static avatars are now being pulled once directly from the CMS instead of pulling a random image everytime from the third-party service.

(nothing changed in the `directus.ts` file, except for stuff from `prettier`)