### PR TITLE
Also build arm64 image

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -69,6 +69,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta-landing-page.outputs.tags }}
           labels: ${{ steps.meta-landing-page.outputs.labels }}
           build-args: |


### PR DESCRIPTION
During local deployments with an ARM64 device, I noticed that the ARM64 image is still missing for the landing page. Since we don't have a dedicated release build here, unlike with Scrumlr itself, I didn't adopt the logic from the main scrumlr repo, which only builds arm64 images for “real” releases.