### PR TITLE
Update Dockerfile and CI configuration to avoid SecretsUsedInArgOrEnv docker warning for DIRECTUS_TOKEN

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,24 @@
+# Dependencies
 node_modules
+
+# Local build/cache artifacts
+.astro
+dist
+
+# Environment files
+.env
+.env.*
+
+# Repository/editor metadata
+.git
+.github
+.vscode
+.idea
+
+# Documentation
+CODE_OF_CONDUCT.md
+README.md
+LICENSE
+
+# Local development / CI helpers
+docker-compose.yml

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -74,5 +74,6 @@ jobs:
           labels: ${{ steps.meta-landing-page.outputs.labels }}
           build-args: |
             DIRECTUS_URL=${{ secrets.DIRECTUS_URL }}
-            DIRECTUS_TOKEN=${{ secrets.DIRECTUS_TOKEN }}
-            PUBLIC_SCRUMLR_SERVER_URL="https://development.scrumlr.fra.ics.inovex.io/api"
+            PUBLIC_SCRUMLR_SERVER_URL=https://development.scrumlr.fra.ics.inovex.io/api
+          secrets: |
+            directus_token=${{ secrets.DIRECTUS_TOKEN }}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -74,6 +74,5 @@ jobs:
           labels: ${{ steps.meta-landing-page.outputs.labels }}
           build-args: |
             DIRECTUS_URL=${{ secrets.DIRECTUS_URL }}
-            PUBLIC_SCRUMLR_SERVER_URL=https://development.scrumlr.fra.ics.inovex.io/api
           secrets: |
             directus_token=${{ secrets.DIRECTUS_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM node:24 AS build
 WORKDIR /app
 
 ARG DIRECTUS_URL
-ARG PUBLIC_SCRUMLR_SERVER_URL
 
 COPY package*.json ./
 RUN npm install -g pnpm
@@ -13,7 +12,6 @@ RUN --mount=type=secret,id=directus_token,required=true sh -c '\
   DIRECTUS_TOKEN_CLEAN="$(tr -d "\r\n" < /run/secrets/directus_token)" && \
   printf "DIRECTUS_URL=%s\n" "$DIRECTUS_URL" > .env && \
   printf "DIRECTUS_TOKEN=%s\n" "$DIRECTUS_TOKEN_CLEAN" >> .env && \
-  printf "PUBLIC_SCRUMLR_SERVER_URL=%s\n" "$PUBLIC_SCRUMLR_SERVER_URL" >> .env && \
   pnpm run build && \
   rm -f .env \
 '

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,22 @@
 FROM node:24 AS build
 WORKDIR /app
+
 ARG DIRECTUS_URL
-ARG DIRECTUS_TOKEN
 ARG PUBLIC_SCRUMLR_SERVER_URL
+
 COPY package*.json ./
 RUN npm install -g pnpm
 RUN pnpm install
 COPY . .
-RUN echo "DIRECTUS_URL = ${DIRECTUS_URL}" >> .env
-RUN echo "DIRECTUS_TOKEN = ${DIRECTUS_TOKEN}" >> .env
-RUN echo "PUBLIC_SCRUMLR_SERVER_URL" = ${PUBLIC_SCRUMLR_SERVER_URL} >> .env
-RUN pnpm run build
-RUN rm -rf .env
+
+RUN --mount=type=secret,id=directus_token,required=true sh -c '\
+  DIRECTUS_TOKEN_CLEAN="$(tr -d "\r\n" < /run/secrets/directus_token)" && \
+  printf "DIRECTUS_URL=%s\n" "$DIRECTUS_URL" > .env && \
+  printf "DIRECTUS_TOKEN=%s\n" "$DIRECTUS_TOKEN_CLEAN" >> .env && \
+  printf "PUBLIC_SCRUMLR_SERVER_URL=%s\n" "$PUBLIC_SCRUMLR_SERVER_URL" >> .env && \
+  pnpm run build && \
+  rm -f .env \
+'
 
 FROM nginx:alpine AS runtime
 COPY ./nginx/nginx.conf /etc/nginx/nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ COPY . .
 
 RUN --mount=type=secret,id=directus_token,required=true sh -c '\
   DIRECTUS_TOKEN_CLEAN="$(tr -d "\r\n" < /run/secrets/directus_token)" && \
-  printf "DIRECTUS_URL=%s\n" "$DIRECTUS_URL" > .env && \
-  printf "DIRECTUS_TOKEN=%s\n" "$DIRECTUS_TOKEN_CLEAN" >> .env && \
+  echo "DIRECTUS_URL=$DIRECTUS_URL" > .env && \
+  echo "DIRECTUS_TOKEN=$DIRECTUS_TOKEN_CLEAN" >> .env && \
   pnpm run build && \
   rm -f .env \
 '

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,11 @@ FROM node:26 AS build
 WORKDIR /app
 
 ARG DIRECTUS_URL
+ARG PUBLIC_SCRUMLR_SERVER_URL
 
 COPY package*.json ./
 COPY pnpm-workspace.yaml ./
+COPY pnpm-lock.yaml ./
 
 RUN npm install -g pnpm
 RUN pnpm install
@@ -14,10 +16,11 @@ COPY . .
 
 RUN --mount=type=secret,id=directus_token,required=true sh -c '\
   DIRECTUS_TOKEN_CLEAN="$(tr -d "\r\n" < /run/secrets/directus_token)" && \
-  echo "DIRECTUS_URL=$DIRECTUS_URL" > .env && \
-  echo "DIRECTUS_TOKEN=$DIRECTUS_TOKEN_CLEAN" >> .env && \
-  pnpm run build && \
-  rm -f .env \
+  env \
+    DIRECTUS_URL="$DIRECTUS_URL" \
+    DIRECTUS_TOKEN="$DIRECTUS_TOKEN_CLEAN" \
+    PUBLIC_SCRUMLR_SERVER_URL="$PUBLIC_SCRUMLR_SERVER_URL" \
+    pnpm run build \
 '
 
 FROM nginx:alpine AS runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:26 AS build
+FROM node:26-slim AS build
 
 WORKDIR /app
 
@@ -14,14 +14,12 @@ COPY . .
 ARG DIRECTUS_URL
 ARG PUBLIC_SCRUMLR_SERVER_URL
 
-RUN --mount=type=secret,id=directus_token,required=true sh -c '\
-  DIRECTUS_TOKEN_CLEAN="$(tr -d "\r\n" < /run/secrets/directus_token)" && \
-  env \
-    DIRECTUS_URL="$DIRECTUS_URL" \
-    DIRECTUS_TOKEN="$DIRECTUS_TOKEN_CLEAN" \
-    PUBLIC_SCRUMLR_SERVER_URL="$PUBLIC_SCRUMLR_SERVER_URL" \
-    pnpm run build \
-'
+RUN --mount=type=secret,id=directus_token,required=true \
+  DIRECTUS_URL="$DIRECTUS_URL" \
+  DIRECTUS_TOKEN="$(tr -d "\r\n" < /run/secrets/directus_token)" \
+  PUBLIC_SCRUMLR_SERVER_URL="$PUBLIC_SCRUMLR_SERVER_URL" \
+  pnpm run build
+
 
 FROM nginx:alpine AS runtime
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,6 @@ FROM node:26 AS build
 
 WORKDIR /app
 
-ARG DIRECTUS_URL
-ARG PUBLIC_SCRUMLR_SERVER_URL
-
 COPY package*.json ./
 COPY pnpm-workspace.yaml ./
 COPY pnpm-lock.yaml ./
@@ -13,6 +10,9 @@ RUN npm install -g pnpm
 RUN pnpm install
 
 COPY . .
+
+ARG DIRECTUS_URL
+ARG PUBLIC_SCRUMLR_SERVER_URL
 
 RUN --mount=type=secret,id=directus_token,required=true sh -c '\
   DIRECTUS_TOKEN_CLEAN="$(tr -d "\r\n" < /run/secrets/directus_token)" && \

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ pnpm start
 Build the image:
 
 ```bash
-❯ DIRECTUS_TOKEN='your-directus-token' docker build \
+DIRECTUS_TOKEN='your-directus-token' docker build \
 -t scrumlr-landing-page \
-  --build-arg DIRECTUS_URL='https://your-directus-url' \
-  --secret id=directus_token,env=DIRECTUS_TOKEN \
-  .
+--build-arg DIRECTUS_URL='https://your-directus-url' \
+ --secret id=directus_token,env=DIRECTUS_TOKEN \
+.
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -36,11 +36,12 @@ pnpm start
 Build the image:
 
 ```bash
-docker build \
-	--build-arg DIRECTUS_URL="https://your-directus-url" \
-	--build-arg DIRECTUS_TOKEN="your-directus-token" \
-	-t scrumlr-landing-page .
+❯ DIRECTUS_TOKEN='your-directus-token' docker build \
+  --build-arg DIRECTUS_URL='https://your-directus-url' \
+  --secret id=directus_token,env=DIRECTUS_TOKEN \
+  .
 ```
+
 
 Run the container:
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Build the image:
 
 ```bash
 ❯ DIRECTUS_TOKEN='your-directus-token' docker build \
+-t scrumlr-landing-page \
   --build-arg DIRECTUS_URL='https://your-directus-url' \
   --secret id=directus_token,env=DIRECTUS_TOKEN \
   .


### PR DESCRIPTION
changes:

Dockerfile: mount directus token as secret instead of arg, cleaning it
CI: set the token as secret instead of build-arg
Readme: adjusted documentation accordingly