### PR TITLE
ci: Add react group to dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,3 +7,10 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 10
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "@types/react"
+          - "react-dom"
+          - "@types/react-dom"


### PR DESCRIPTION
Add a react group to the dependabot configuration to update the needed react packages in one merge request