### PR TITLE
chore: update gh actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,3 +14,18 @@ updates:
           - "@types/react"
           - "react-dom"
           - "@types/react-dom"
+
+   # github actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 10
+    open-pull-requests-limit: 10
+    target-branch: "main"
+    labels:
+      - "Dependencies"
+    commit-message:
+      prefix: "gha"
+      include: "scope"

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Code Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Corepack # for pnpm
         run: |
@@ -20,7 +20,7 @@ jobs:
           corepack install
 
       - name: Install NodeJS
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -47,10 +47,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Login Github Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -58,7 +58,7 @@ jobs:
 
       - name: scrumlr.io - Landing Page - Build
         id: meta-landing-page
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ghcr.io/inovex/scrumlr.io-landing-page/image
@@ -78,11 +78,11 @@ jobs:
             org.opencontainers.image.description=The landing page of scrumlr.io
 
       - name: Set up Docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Push landing page image
         id: push-landing-page
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           push: true
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This MR updates the github action dependencies to their newest version.
It also adds a dependabot configuration to make merge requests to update the github action dependencies.